### PR TITLE
Fix "Benne" font not loading

### DIFF
--- a/themes/hojicha/static/css/style.css
+++ b/themes/hojicha/static/css/style.css
@@ -5,34 +5,34 @@
     --jasmine-green: #AEBF99;
     --hojicha-green: #899D70;
     --pine-green: #6E8551;
-
+    
     --bg-color: var(--light-gray);
     --font-color: var(--dark-gray);
     --accent: var(--jasmine-green);
     --dark-accent: var(--hojicha-green);
     --dark-dark-accent: var(--pine-green);
-
+    
     /* Measurements */
     --container-width: 800px;
     --max-width: 700px;
     --border-radius: 3px;
     --font-size: 1rem;
-
+    
     --transition-duration: 0.3s
-}
+}    
 
 @font-face {
     font-family: "Aeonik";
-    src: url("../fonts/Aeonik-Regular.otf") format("opentype");
+    src: url("/fonts/Aeonik-Regular.otf") format("opentype");
 }
 @font-face {
     font-family: "Aeonik";
     font-weight: bold;
-    src: url("../fonts/Aeonik-Bold.otf") format("opentype");
+    src: url("/fonts/Aeonik-Bold.otf") format("opentype");
 }
 @font-face {
     font-family: "Benne";
-    src: url("../fonts/Benne-Regular.otf") format("opentype");
+    src: url("/fonts/Benne-Regular.ttf") format("truetype");
 }
 
 .secondary-font {


### PR DESCRIPTION
The "Benne" font wasn't being loaded properly because we were trying to import it as a `.otf` file when it was actually a `.ttf` file. This means that users would've seen Times New Roman or whatever other default font their web browser defaults to.

Before:
![image](https://user-images.githubusercontent.com/43258911/140247517-37c057cb-1f47-4ff2-997f-1b208d1cf336.png)

After:
![image](https://user-images.githubusercontent.com/43258911/140247493-770aca8a-3ae1-41bb-8e90-c0c9c7549fbb.png)
